### PR TITLE
useBurpProxy

### DIFF
--- a/dotnetpaddingoracle.py
+++ b/dotnetpaddingoracle.py
@@ -141,7 +141,7 @@ def testIfOracle(sampleFile, targetParameter):
 	
 	[url,headers,data,method] = mt.parseBurpData(sampleFile)
 	print("Test if \'"+targetParameter+"\' is an Oracle") 
-	opener = mt.createOpener(withBurpProxy=False)
+	opener = mt.createOpener(withBurpProxy=useBurpProxy)
 	print("data=", data[targetParameter])
 	try:
 		initialCipherText = mt.decodeASP(data[targetParameter].encode())


### PR DESCRIPTION
This patch ensures Burp is used in test mode (`-t, --test-vuln`) by default unless the "-b" flag is specified.

dotnetpaddingoracle will try to connect through burp (for debugging purposes) via 127.0.0.1:8080 (configurable in mtools.py) by default.

You can opt-out by specifying the "-b" flag:
`-b, --no-burp         Disable Burp proxying`

However, the Burp proxy is blatantly ignored in the `testIfOracle` function on line 144 regardless of whether the `-b` flag is set:
`opener = mt.createOpener(withBurpProxy=False)`
